### PR TITLE
default to false for $hosts

### DIFF
--- a/puppet/modules/site_config/manifests/hosts.pp
+++ b/puppet/modules/site_config/manifests/hosts.pp
@@ -1,5 +1,5 @@
 class site_config::hosts() {
-  $hosts         = hiera('hosts','')
+  $hosts         = hiera('hosts', false)
   $hostname      = hiera('name')
   $domain_hash   = hiera('domain')
   $domain_public = $domain_hash['full_suffix']


### PR DESCRIPTION
there are a lot of places where hiera files have nil values specified. for example, if the node has no location information, then 'location' is nil. this seems right and good to me, but hiera will freak out if location is nil and you do hiera('location') without specifying a default.

that is too bad, because non-existent is really different than set to nil. anyway, this seems like a bug in hiera to me.

to make a long story short, we may have to change how leap_cli generates hiera files, and replace nil values with false.

instead, for now, this commit specifies 'false' as the default for 'hosts'.
