### PR TITLE
security related changes to webapp

### DIFF
--- a/provider_base/services/webapp.json
+++ b/provider_base/services/webapp.json
@@ -1,5 +1,6 @@
 {
   "webapp": {
+    "admins": [],
     "modules": ["user", "billing", "help"],
     "couchdb_admin_user": "= global.services[:couchdb].couch.users[:admin]",
 //    "couchdb_webapp_user": "= global.services[:couchdb].couch.users[:webapp]",

--- a/puppet/modules/site_webapp/templates/config.yml.erb
+++ b/puppet/modules/site_webapp/templates/config.yml.erb
@@ -1,6 +1,6 @@
 <%- cert_options = @webapp['client_certificates'] -%>
 production:
-  admins: [admin]
+  admins: <%= @webapp['admins'].inspect %>
   domain: <%= @provider_domain %>
   force_ssl: <%= @webapp['secure'] %>
   client_ca_key: <%= scope.lookupvar('site_webapp::client_ca::key_path') %>


### PR DESCRIPTION
two things
- add config webapp.secure, default to false. if true, cookies are secure and hsts is turned on.
- add config webapp.admins, default to empty list. if configured, these accounts will get admin access in the webapp.
