### PR TITLE
add weights and backup servers to haproxy

### DIFF
--- a/platform.rb
+++ b/platform.rb
@@ -4,7 +4,7 @@
 
 Leap::Platform.define do
   self.version = "0.2.3"
-  self.compatible_cli = "1.1.4".."1.99"
+  self.compatible_cli = "1.2.1".."1.99"
 
   #
   # the facter facts that should be gathered

--- a/puppet/modules/site_webapp/templates/haproxy_couchdb.cfg.erb
+++ b/puppet/modules/site_webapp/templates/haproxy_couchdb.cfg.erb
@@ -1,16 +1,23 @@
 
 listen bigcouch-in
-  mode http
+  mode     http
   balance  roundrobin
-  option httplog
-  option dontlognull
-  option httpchk GET /
-  option http-server-close
-  
+  option   httplog
+  option   dontlognull
+  option   httpchk GET /        # health check using simple get to root
+  option   http-server-close    # use client keep-alive, but close server connection.
+  option   allbackups           # balance among all backups, not just one.
+
   bind localhost:4096
-<% for port in @local_ports -%>
-  server couchdb_<%=port%> localhost:<%=port%> check inter 3000 fastinter 1000 downinter 1000 rise 2 fall 1
-<% end -%>
 
+  default-server inter 3000 fastinter 1000 downinter 1000 rise 2 fall 1
 
+<%- if @haproxy['servers'] -%>
+<%-   @haproxy['servers'].each do |name,server| -%>
+<%-     backup = server['backup'] ? 'backup' : '' -%>
+  # <%=name%>
+  server couchdb_<%=server['port']%> <%=server['host']%>:<%=server['port']%> <%=backup%> weight <%=server['weight']%> check
+
+<%-   end -%>
+<%- end -%>
 


### PR DESCRIPTION
this requires leap_cli 1.2.1 to work correctly. 

if there are no "close" couchdb nodes, then all are weighted equally and there are no backups.

if there are some close couchdb nodes, these are weighted more and the rest are set as backups.

currently, we don't use timezone to figure out relative weights, we just distinguish between local and non-local. effectively, this means the 'weight' is not really used, just the 'backup' option. in the future, we might make weight mean something real.

"option allbackups" is required so that all backup servers will be used, not just a single one (if ever non-backup server is dead).
