### PR TITLE
added support for minimum client version checking

### DIFF
--- a/provider_base/provider.json
+++ b/provider_base/provider.json
@@ -50,5 +50,9 @@
       "unlimited_prefix": "UNLIMITED"
     }
   },
-  "hiera_sync_destination": "/etc/leap"
+  "hiera_sync_destination": "/etc/leap",
+  "client_version": {
+    "min": "0.5",
+    "max": null
+  }
 }

--- a/provider_base/services/webapp.json
+++ b/provider_base/services/webapp.json
@@ -14,7 +14,8 @@
     "git": {
       "source": "https://leap.se/git/leap_web",
       "revision": "origin/master"
-    }
+    },
+    "client_version": "= global.provider.client_version"
   },
   "stunnel": {
     "couch_client": "= stunnel_client(nodes_like_me[:services => :couchdb], global.services[:couchdb].couch.port)"

--- a/puppet/modules/site_webapp/manifests/init.pp
+++ b/puppet/modules/site_webapp/manifests/init.pp
@@ -80,10 +80,19 @@ class site_webapp {
   }
 
   file {
-    '/srv/leap/webapp/public/provider.json':
+    "/srv/leap/webapp/config/provider":
+      ensure  => directory,
+      require => Vcsrepo['/srv/leap/webapp'],
+      owner   => leap-webapp, group => leap-webapp, mode => '0755';
+
+    '/srv/leap/webapp/config/provider/provider.json':
       content => $provider,
       require => Vcsrepo['/srv/leap/webapp'],
       owner   => leap-webapp, group => leap-webapp, mode => '0644';
+
+    # old provider.json location. this can be removed after everyone upgrades.
+    '/srv/leap/webapp/public/provider.json':
+      ensure => absent;
 
     '/srv/leap/webapp/public/ca.crt':
       ensure  => link,

--- a/puppet/modules/site_webapp/templates/config.yml.erb
+++ b/puppet/modules/site_webapp/templates/config.yml.erb
@@ -14,3 +14,4 @@ production:
   allow_anonymous_certs: <%= @webapp['allow_anonymous_certs'].inspect %>
   limited_cert_prefix: "<%= cert_options['limited_prefix'] %>"
   unlimited_cert_prefix: "<%= cert_options['unlimited_prefix'] %>"
+  minimum_client_version: "<%= @webapp['client_version']['min'] %>"


### PR DESCRIPTION
with this change, the client will be able to read the X-Minimum-Client-Version header when fetching /provider.json.

this won't work until the corresponding pull request for leap_web is merged, which should happen shortly.

yes, i know we are in feature freeze, but this is a much needed feature before we go public beta.
