### PR TITLE
new monitor hosts rule

### DIFF
--- a/provider_base/services/monitor.json
+++ b/provider_base/services/monitor.json
@@ -1,9 +1,9 @@
 {
   "nagios": {
     "nagiosadmin_pw": "= secret :nagios_admin_password",
-    "hosts": "= nodes_like_me[:services => '!monitor'].pick_fields('domain.internal', 'ip_address', 'services', 'openvpn.gateway_address')"
+    "hosts": "= (self.environment == 'local' ? nodes_like_me : nodes[:environment => '!local']).pick_fields('domain.internal', 'ip_address', 'services', 'openvpn.gateway_address')"
   },
-  "hosts": "= hosts_file(nodes_like_me[:services => '!monitor'])",
+  "hosts": "= self.environment == 'local' ? hosts_file(nodes_like_me) : hosts_file(nodes[:environment => '!local'])",
   "ssh": {
     "monitor": {
       "username": "= Leap::Platform.monitor_username",


### PR DESCRIPTION
local environment monitors just see local machines, other monitors see the nodes from all environments (except local)
