### PR TITLE
added a checkmk mode to run_tests

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -60,6 +60,20 @@ class LeapTest < MiniTest::Unit::TestCase
   end
 
   #
+  # returns all the test classes, sorted in dependency order.
+  #
+  def self.test_classes
+    classes = ObjectSpace.each_object(Class).select {|test_class|
+      test_class.ancestors.include?(self)
+    }
+    return TestDependencyGraph.new(classes).sorted
+  end
+
+  def self.tests
+    self.instance_methods.grep(/^test_/).sort
+  end
+
+  #
   # The default pass just does an `assert true`. In our case, we want to make the passes more explicit.
   #
   def pass
@@ -272,9 +286,16 @@ class LeapRunner < MiniTest::Unit
   #       LeapTest._run
   #
   def _run args = []
-    suites = LeapTest.send "test_suites"
+    if $pinned_test_class
+      suites = [$pinned_test_class]
+      if $pinned_test_method
+        options.merge!(:filter => $pinned_test_method.to_s)
+      end
+    else
+      suites = LeapTest.send "test_suites"
+      suites = TestDependencyGraph.new(suites).sorted
+    end
     output.sync = true
-    suites = TestDependencyGraph.new(suites).sorted
     results = _run_suites(suites, :test)
     @test_count      = results.inject(0) { |sum, (tc, _)| sum + tc }
     @assertion_count = results.inject(0) { |sum, (_, ac)| sum + ac }
@@ -418,36 +439,90 @@ class TestDependencyGraph
 end
 
 ##
-## RUN THE TESTS
+## COMMAND LINE ACTIONS
 ##
 
-# load node data from hiera file
-if File.exists?('/etc/leap/hiera.yaml')
-  $node = YAML.load_file('/etc/leap/hiera.yaml')
-else
-  $node = {"services" => [], "dummy" => true}
+def die(test, msg)
+  if $output_format == :human
+    puts "ERROR in test `#{test}`: #{msg}"
+  elsif $output_format == :checkmk
+    puts "3 #{test} - #{msg}"
+  end
+  exit(1)
 end
 
-# load all test classes
-this_file = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
-Dir[File.expand_path('../../tests/white-box/*.rb', this_file)].each do |test_file|
-  begin
-    require test_file
-  rescue SkipTest
+def print_help
+  puts ["USAGE: run_tests [OPTIONS]",
+       "  --continue     Don't halt on an error, but continue to the next test.",
+       "  --checkmk      Print test results in checkmk format (must come before --test).",
+       "  --test TEST    Run only the test with name TEST.",
+       "  --list-tests   Prints the names of all available tests and exit."].join("\n")
+  exit(0)
+end
+
+def list_tests
+  LeapTest.test_classes.each do |test_class|
+    test_class.tests.each do |test|
+      puts test_class.name + "/" + test.to_s.sub(/^test_(\d+_)?/, '')
+    end
+  end
+  exit(0)
+end
+
+def pin_test_name(name)
+  test_class, test_name = name.split('/')
+  $pinned_test_class = LeapTest.test_classes.detect{|c| c.name == test_class}
+  unless $pinned_test_class
+    die name, "there is no test class `#{test_class}`"
+  end
+  if test_name
+    $pinned_test_method = $pinned_test_class.tests.detect{|m| m.to_s =~ /^test_(\d+_)?#{test_name}$/}
+    unless $pinned_test_method
+      die name, "there is no test `#{test_name}` in class `#{test_class}`"
+    end
   end
 end
 
-# parse command line options
-$halt_on_failure = true
-$output_format = :human
-loop do
-  case ARGV[0]
-    when '--continue' then ARGV.shift; $halt_on_failure = false
-    when '--checkmk' then ARGV.shift; $output_format = :checkmk; $halt_on_failure = false
-    else break
-  end
+def run_tests
+  MiniTest::Unit.runner = LeapRunner.new
+  MiniTest::Unit.new.run
 end
 
-# run some tests already
-MiniTest::Unit.runner = LeapRunner.new
-MiniTest::Unit.new.run
+##
+## MAIN
+##
+
+def main
+  # load node data from hiera file
+  if File.exists?('/etc/leap/hiera.yaml')
+    $node = YAML.load_file('/etc/leap/hiera.yaml')
+  else
+    $node = {"services" => [], "dummy" => true}
+  end
+
+  # load all test classes
+  this_file = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
+  Dir[File.expand_path('../../tests/white-box/*.rb', this_file)].each do |test_file|
+    begin
+      require test_file
+    rescue SkipTest
+    end
+  end
+
+  # parse command line options
+  $halt_on_failure = true
+  $output_format = :human
+  loop do
+    case ARGV[0]
+      when '--continue' then ARGV.shift; $halt_on_failure = false;
+      when '--checkmk' then ARGV.shift; $output_format = :checkmk; $halt_on_failure = false
+      when '--help' then print_help
+      when '--test' then ARGV.shift; pin_test_name(ARGV.shift)
+      when '--list-tests' then list_tests
+      else break
+    end
+  end
+  run_tests
+end
+
+main()


### PR DESCRIPTION
added a checkmk mode to the script `run_tests` (run with `run_tests --checkmk`. you can symlink `/srv/leap/bin/run_tests` script to anywhere as needed)
