### PR TITLE
DirPortFrontPage serves a static webpage only when Tor node is exit.

### DIFF
--- a/puppet/modules/site_tor/manifests/init.pp
+++ b/puppet/modules/site_tor/manifests/init.pp
@@ -24,7 +24,7 @@ class site_tor {
   }
   else {
     tor::daemon::directory { $::hostname:
-      port => 80,
+      port            => 80,
       port_front_page => '';
     }
     include site_tor::disable_exit


### PR DESCRIPTION
DirPortFrontPage is set only when Tor node is exit. See leap.se/code/issues/5241 . This is also related to https://github.com/irregulator/puppet_tor/commit/44f62cacdfe5f27dc34c46a1f4b2918a651d12c9
