### PR TITLE
Fix dhcp on virtualbox

### DIFF
--- a/puppet/modules/site_config/manifests/default.pp
+++ b/puppet/modules/site_config/manifests/default.pp
@@ -27,6 +27,9 @@ class site_config::default {
   if $::ec2_instance_id {
     include site_config::dhclient
   }
+  if $::virtual == 'virtualbox' {
+    include site_config::dhclient
+  }
 
   # configure /etc/resolv.conf
   include site_config::resolvconf


### PR DESCRIPTION
virtualbox has the same problems with dhcp as ec2.
Tell dhclient not to edit /erc/resolv.conf if running on virtualbox
