### PR TITLE
move hiera from site.pp to site_config::setup

### DIFF
--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -1,9 +1,6 @@
 # set a default exec path
 Exec { path => '/usr/bin:/usr/sbin/:/bin:/sbin:/usr/local/bin:/usr/local/sbin' }
 
-# parse services for host
-$services=join(hiera_array('services', ['']), ' ')
-notice("Services for ${fqdn}: ${services}")
 
 include site_config::setup
 include site_config::default

--- a/puppet/modules/site_config/manifests/setup.pp
+++ b/puppet/modules/site_config/manifests/setup.pp
@@ -13,6 +13,10 @@ class site_config::setup {
   include concat::setup
   include stdlib
 
+
+  # parse services for host
+  $services=join(hiera_array('services', ['']), ' ')
+  notice("Services for ${fqdn}: ${services}")
   # configure /etc/hosts
   class { 'site_config::hosts':
     stage => setup,


### PR DESCRIPTION
the problem was following:

if a host has the webapp service, the template for /etc/hosts adds some stuff.
But setup.pp did not ask hiera about the services so
"/srv/leap/bin/puppet_command set_hostname" always resets the hostname.
Since that gets triggered every time you run "leap deploy" the
hostname changes, some services restart, then the hostname changes back and
the services restart again.

The solution is to get the hiera data before every run.
