### PR TITLE
tests: fixed problem with showing couchdb password in process table, and...

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -122,7 +122,7 @@ class LeapTest < MiniTest::Unit::TestCase
   #
   # attempts a http GET on the url, yields |body, response, error|
   #
-  def get(url, params=nil)
+  def get(url, params=nil, options=nil)
     uri = URI(url)
     if params
       uri.query = URI.encode_www_form(params)
@@ -133,7 +133,11 @@ class LeapTest < MiniTest::Unit::TestCase
       http.use_ssl = true
     end
     http.start do |agent|
-      response = agent.get(uri.request_uri)
+      request = Net::HTTP::Get.new uri.request_uri
+      if options && options[:username]
+        request.basic_auth options[:username], options[:password]
+      end
+      response = agent.request(request)
       if response.is_a?(Net::HTTPSuccess)
         yield response.body, response, nil
       else
@@ -146,7 +150,7 @@ class LeapTest < MiniTest::Unit::TestCase
 
   def assert_get(url, params=nil, options=nil)
     options ||= {}
-    get(url, params) do |body, response, error|
+    get(url, params, options) do |body, response, error|
       if body
         yield body if block_given?
       elsif response
@@ -155,6 +159,19 @@ class LeapTest < MiniTest::Unit::TestCase
         fail ["Expected a response from #{url}, but got \"#{error}\" instead.", options[:error_msg]].compact.join("\n")
       end
     end
+  end
+
+  #
+  # only a warning for now, should be a failure in the future
+  #
+  def assert_auth_fail(url, params, auth_options)
+    get(url, params, auth_options) do |body, response, error|
+      unless response.code == 401
+        warn "Expected a '401 Unauthorized' response, but got #{response.code} instead (GET #{url} with username '#{auth_options[:username]}')."
+        return false
+      end
+    end
+    true
   end
 
   #

--- a/tests/white-box/couchdb.rb
+++ b/tests/white-box/couchdb.rb
@@ -33,7 +33,7 @@ class CouchDB < LeapTest
     neighbors = assert_property('couch.bigcouch.neighbors')
     neighbors << assert_property('domain.full')
     neighbors.sort!
-    assert_get(url) do |body|
+    assert_get(url, nil, http_basic_auth) do |body|
       response = JSON.parse(body)
       nodes_in_db = response['rows'].collect{|row| row['id'].sub(/^bigcouch@/, '')}.sort
       assert_equal neighbors, nodes_in_db, "The couchdb replication node list is wrong (/nodes/_all_docs)"
@@ -49,7 +49,7 @@ class CouchDB < LeapTest
   #
   def test_03_Are_configured_nodes_online?
     url = couchdb_url("/_membership")
-    assert_get(url) do |body|
+    assert_get(url, nil, http_basic_auth) do |body|
       response = JSON.parse(body)
       nodes_configured_but_not_available = response['cluster_nodes'] - response['all_nodes']
       nodes_available_but_not_configured = response['all_nodes'] - response['cluster_nodes']
@@ -68,7 +68,7 @@ class CouchDB < LeapTest
   def test_04_Do_ACL_users_exist?
     acl_users = ['_design/_auth', 'leap_mx', 'nickserver', 'soledad', 'tapicero', 'webapp']
     url = couchdb_backend_url("/_users/_all_docs")
-    assert_get(url) do |body|
+    assert_get(url, nil, http_basic_auth) do |body|
       response = JSON.parse(body)
       assert_equal 6, response['total_rows']
       actual_users = response['rows'].map{|row| row['id'].sub(/^org.couchdb.user:/, '') }
@@ -88,6 +88,23 @@ class CouchDB < LeapTest
     pass
   end
 
+  #
+  # for now, this just prints warnings, since we are failing these tests.
+  #
+  def test_06_Is_ACL_enforced?
+    ok = assert_auth_fail(
+      couchdb_url('/users/_all_docs'),
+      {:limit => 1},
+      http_basic_auth('leap_mx')
+    )
+    ok = assert_auth_fail(
+      couchdb_url('/users/_all_docs'),
+      {:limit => 1},
+      {}
+    ) && ok
+    pass if ok
+  end
+
   private
 
   def couchdb_url(path="", port=nil)
@@ -95,15 +112,17 @@ class CouchDB < LeapTest
       assert_property 'couch.port'
       $node['couch']['port']
     end
-    @password ||= begin
-      assert_property 'couch.users.admin.password'
-      $node['couch']['users']['admin']['password']
-    end
-    "http://admin:#{@password}@localhost:#{port || @port}#{path}"
+    "http://localhost:#{port || @port}#{path}"
   end
 
   def couchdb_backend_url(path="")
     couchdb_url(path, "5986") # TODO: admin port is hardcoded for now but should be configurable.
+  end
+
+  def http_basic_auth(username='admin')
+    assert_property 'couch.users.' + username
+    password = $node['couch']['users'][username]['password']
+    {:username => username, :password => password}
   end
 
 end


### PR DESCRIPTION
... adding warnings for when ACL is not being respected (which is currently always). closes #5445
