### PR TITLE
reorder /etc/hosts

### DIFF
--- a/puppet/modules/site_config/manifests/hosts.pp
+++ b/puppet/modules/site_config/manifests/hosts.pp
@@ -10,10 +10,9 @@ class site_config::hosts() {
   } else {
     $dns_aliases = $dns['aliases']
   }
-  $my_hostnames = unique(sort(concat(
-    [$hostname, $domain_hash['full'], $domain_hash['internal']],
-    $dns_aliases
-  )))
+  $my_hostnames = unique(concat(
+    $dns_aliases, [$hostname, $domain_hash['full'], $domain_hash['internal']]
+  ))
 
   file { '/etc/hostname':
     ensure  => present,


### PR DESCRIPTION
now "hostname -f" results in the correct hostname.
Fixes #5835
