### PR TITLE
add replication role to user databases with tapicero

### DIFF
--- a/puppet/modules/tapicero/templates/tapicero.yaml.erb
+++ b/puppet/modules/tapicero/templates/tapicero.yaml.erb
@@ -40,10 +40,11 @@ options:
         # explicit about this
         - <%= @couchdb_admin_user %>
       roles: []
-    readers:
+    members:
       names:
         - <%= @couchdb_soledad_user %>
         - <%= @couchdb_leap_mx_user %>
-      roles: []
+      roles:
+        - replication
 
 


### PR DESCRIPTION
This way the replication has read access on the source and write access on the target.
