### PR TITLE
Help to fix: #5952 webapp now logs to it's own file instead of syslog and user.log.

### DIFF
--- a/puppet/modules/site_webapp/manifests/init.pp
+++ b/puppet/modules/site_webapp/manifests/init.pp
@@ -16,6 +16,7 @@ class site_webapp {
   include site_config::ruby::dev
   include site_webapp::apache
   include site_webapp::couchdb
+  include site_webapp::logging
   include site_haproxy
   include site_webapp::cron
   include site_config::x509::cert

--- a/puppet/modules/site_webapp/manifests/logging.pp
+++ b/puppet/modules/site_webapp/manifests/logging.pp
@@ -1,0 +1,16 @@
+class site_webapp::logging {
+
+  rsyslog::snippet { '01-webapp':
+    content => 'if $programname == "webapp" then /var/log/leap/webapp.log
+stop'
+  }
+
+  augeas {
+    'logrotate_webapp':
+      context => '/files/etc/logrotate.d/webapp/rule',
+      changes => [ 'set file /var/log/leap/webapp.log', 'set rotate 7',
+                   'set schedule daily', 'set compress compress',
+                   'set missingok missingok', 'set ifempty notifempty',
+                   'set copytruncate copytruncate' ]
+  }
+}


### PR DESCRIPTION
The log rotates daily and it's kept for 7 days. This helps to reduce the disk space taken by logs.
