### PR TITLE
small fixes to tests

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -41,6 +41,7 @@ end
 ##
 
 # this class is raised if a test file wants to be skipped entirely.
+# (to skip an individual test, MiniTest::Skip is used instead)
 class SkipTest < Exception
 end
 
@@ -61,6 +62,8 @@ end
 #
 class LeapTest < MiniTest::Unit::TestCase
   class Pass < MiniTest::Assertion
+  end
+  class Ignore < MiniTest::Assertion
   end
 
   def initialize(name)
@@ -98,6 +101,13 @@ class LeapTest < MiniTest::Unit::TestCase
   #
   def pass
     raise LeapTest::Pass
+  end
+
+  #
+  # Called when the test should be silently ignored.
+  #
+  def ignore
+    raise LeapTest::Ignore
   end
 
   #
@@ -332,6 +342,7 @@ class LeapRunner < MiniTest::Unit
   def initialize
     @passes = 0
     @warnings = 0
+    @ignores = 0
     super
   end
 
@@ -372,9 +383,12 @@ class LeapRunner < MiniTest::Unit
     case e
       when MiniTest::Skip then
         @skips += 1
-        #if @verbose
-          report_line("SKIP", klass, meth, e, e.message)
-        #end
+        report_line("SKIP", klass, meth, e, e.message)
+      when LeapTest::Ignore then
+        @ignores += 1
+        if @verbose
+          report_line("IGNORE", klass, meth, e, e.message)
+        end
       when LeapTest::Pass then
         @passes += 1
         report_line("PASS", klass, meth)
@@ -414,7 +428,8 @@ class LeapRunner < MiniTest::Unit
     elsif @failures > 0
       :failure
     elsif @warnings > 0
-      :warning
+      # :warning << warnings don't warrant a non-zero exit code.
+      :success
     else
       :success
     end

--- a/tests/white-box/network.rb
+++ b/tests/white-box/network.rb
@@ -26,35 +26,35 @@ class Network < LeapTest
   #     connect: "127.0.0.1:5984"
   #
   def test_02_Is_stunnel_running?
-    if $node['stunnel']
-      good_stunnel_pids = []
-      $node['stunnel']['clients'].each do |stunnel_type, stunnel_configs|
-        stunnel_configs.each do |stunnel_name, stunnel_conf|
-          config_file_name = "/etc/stunnel/#{stunnel_name}.conf"
-          processes = pgrep(config_file_name)
-          assert_equal 6, processes.length, "There should be six stunnel processes running for `#{config_file_name}`"
-          good_stunnel_pids += processes.map{|ps| ps[:pid]}
-          assert port = stunnel_conf['accept_port'], 'Field `accept_port` must be present in `stunnel` property.'
-          assert_tcp_socket('localhost', port)
-        end
-      end
-      $node['stunnel']['servers'].each do |stunnel_name, stunnel_conf|
+    ignore unless $node['stunnel']
+    good_stunnel_pids = []
+    $node['stunnel']['clients'].each do |stunnel_type, stunnel_configs|
+      stunnel_configs.each do |stunnel_name, stunnel_conf|
         config_file_name = "/etc/stunnel/#{stunnel_name}.conf"
         processes = pgrep(config_file_name)
         assert_equal 6, processes.length, "There should be six stunnel processes running for `#{config_file_name}`"
         good_stunnel_pids += processes.map{|ps| ps[:pid]}
-        assert accept_port = stunnel_conf['accept_port'], "Field `accept` must be present in property `stunnel.servers.#{stunnel_name}`"
-        assert_tcp_socket('localhost', accept_port)
-        assert connect_port = stunnel_conf['connect_port'], "Field `connect` must be present in property `stunnel.servers.#{stunnel_name}`"
-        assert_tcp_socket('localhost', connect_port)
+        assert port = stunnel_conf['accept_port'], 'Field `accept_port` must be present in `stunnel` property.'
+        assert_tcp_socket('localhost', port)
       end
-      all_stunnel_pids = pgrep('/usr/bin/stunnel').collect{|process| process[:pid]}.uniq
-      assert_equal good_stunnel_pids.sort, all_stunnel_pids.sort, "There should not be any extra stunnel processes that are not configured in /etc/stunnel"
-      pass
     end
+    $node['stunnel']['servers'].each do |stunnel_name, stunnel_conf|
+      config_file_name = "/etc/stunnel/#{stunnel_name}.conf"
+      processes = pgrep(config_file_name)
+      assert_equal 6, processes.length, "There should be six stunnel processes running for `#{config_file_name}`"
+      good_stunnel_pids += processes.map{|ps| ps[:pid]}
+      assert accept_port = stunnel_conf['accept_port'], "Field `accept` must be present in property `stunnel.servers.#{stunnel_name}`"
+      assert_tcp_socket('localhost', accept_port)
+      assert connect_port = stunnel_conf['connect_port'], "Field `connect` must be present in property `stunnel.servers.#{stunnel_name}`"
+      assert_tcp_socket('localhost', connect_port)
+    end
+    all_stunnel_pids = pgrep('/usr/bin/stunnel').collect{|process| process[:pid]}.uniq
+    assert_equal good_stunnel_pids.sort, all_stunnel_pids.sort, "There should not be any extra stunnel processes that are not configured in /etc/stunnel"
+    pass
   end
 
   def test_03_Is_shorewall_running?
+    ignore unless File.exists?('/sbin/shorewall')
     assert_run('/sbin/shorewall status')
     pass
   end


### PR DESCRIPTION
make warnings not produce a non-zero exit code, add 'ignore' command to tests, make shorewall optional.
