### PR TITLE
allow outgoing port 3142 for apt-cacher proxy

### DIFF
--- a/puppet/modules/site_config/templates/ipv4firewall_up.rules.erb
+++ b/puppet/modules/site_config/templates/ipv4firewall_up.rules.erb
@@ -2,7 +2,7 @@
 *filter
 :INPUT DROP [0:0]
 :FORWARD DROP [0:0]
-:OUTPUT DROP [0:0]
+:OUTPUT ACCEPT [0:0]
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p tcp -m state --state NEW,ESTABLISHED --dport 22 -j ACCEPT
@@ -11,15 +11,4 @@
 -A INPUT -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p icmp -m icmp --icmp-type 0 -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -m limit --limit 5/min -j LOG --log-prefix "iptables denied: " --log-level 7
--A OUTPUT -o lo -j ACCEPT
--A OUTPUT -p icmp -m icmp --icmp-type 0 -m state --state RELATED,ESTABLISHED -j ACCEPT
--A OUTPUT -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
--A OUTPUT -p tcp -m state --state NEW,ESTABLISHED --sport 22 -j ACCEPT
--A OUTPUT -p tcp -m state --state NEW,ESTABLISHED --sport <%= @ssh_port %> -j ACCEPT
--A OUTPUT -p tcp -m state --state NEW,ESTABLISHED --dport 80 -j ACCEPT
--A OUTPUT -p tcp -m state --state NEW,ESTABLISHED --dport 443 -j ACCEPT
--A OUTPUT -p tcp -m state --state NEW,ESTABLISHED --dport 3142 -j ACCEPT
--A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
--A OUTPUT -p udp -m udp --dport 123 -j ACCEPT
--A OUTPUT -m limit --limit 5/min -j LOG --log-prefix "iptables denied: " --log-level 7
 COMMIT


### PR DESCRIPTION
I want to use apt-proxy-ng during installation to speed up the installation of debian
packages. This rule allows connections to any apt-proxy
