### PR TITLE
Add emacs/vim modelines to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
 Vagrant.configure("2") do |config|
   config.vm.define :node1 do |config|
 


### PR DESCRIPTION
Makes most editors recognize Vagrantfile as a ruby file and do
appropriate syntax highlighting