### PR TITLE
Fix the failing soledad test when invite codes are enabled

### DIFF
--- a/tests/helpers/bonafide_helper.rb
+++ b/tests/helpers/bonafide_helper.rb
@@ -36,7 +36,8 @@ class LeapTest
     params = user.to_params
 
     if property('webapp.invite_required')
-      params['user[invite_code]'] = generate_invite_code
+      @invite_code = generate_invite_code
+      params['user[invite_code]'] = @invite_code
     end
 
     assert_post(url, params) do |body|

--- a/tests/helpers/bonafide_helper.rb
+++ b/tests/helpers/bonafide_helper.rb
@@ -32,13 +32,24 @@ class LeapTest
   def assert_create_user
     user = SRP::User.new
     url = api_url("/1/users.json")
-    assert_post(url, user.to_params) do |body|
+
+    params = user.to_params
+    params['user[invite_code]'] = generate_invite_code
+
+    assert_post(url, params) do |body|
       assert response = JSON.parse(body), 'response should be JSON'
       assert response['ok'], "Creating a user should be successful, got #{response.inspect} instead."
     end
     user.ok = true
     return user
   end
+
+  def generate_invite_code
+    if property('webapp.invite_required')
+      `cd /srv/leap/webapp/ && sudo RAILS_ENV=production bundle exec rake generate_invites[1]`.gsub(/\n/, "")
+    end
+  end
+
 
   #
   # attempts to authenticate user. if successful,

--- a/tests/helpers/bonafide_helper.rb
+++ b/tests/helpers/bonafide_helper.rb
@@ -34,7 +34,10 @@ class LeapTest
     url = api_url("/1/users.json")
 
     params = user.to_params
-    params['user[invite_code]'] = generate_invite_code
+
+    if property('webapp.invite_required')
+      params['user[invite_code]'] = generate_invite_code
+    end
 
     assert_post(url, params) do |body|
       assert response = JSON.parse(body), 'response should be JSON'
@@ -45,9 +48,7 @@ class LeapTest
   end
 
   def generate_invite_code
-    if property('webapp.invite_required')
-      `cd /srv/leap/webapp/ && sudo RAILS_ENV=production bundle exec rake generate_invites[1]`.gsub(/\n/, "")
-    end
+    `cd /srv/leap/webapp/ && sudo -u leap-webapp RAILS_ENV=production bundle exec rake generate_invites[1]`.gsub(/\n/, "")
   end
 
 


### PR DESCRIPTION
When invite codes are required, the soledad sync test will now pass again because an invite code will be generated for the user creation test.