### PR TITLE
look for tests in custom directory

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -33,7 +33,8 @@ HELPER_PATHS = [
 ]
 TEST_PATHS   = [
   '../../tests/white-box/*.rb',
-  '/srv/leap/files/tests/white-box/*.rb'
+  '/srv/leap/files/tests/white-box/*.rb',
+  '/srv/leap/tests_custom/*.rb'
 ]
 
 ##


### PR DESCRIPTION
if 3rd parties want to add tests that get run
by 'leap test' they can now just drop them in
/srv/leap/tests_custom/ and they wil 'just work'