### PR TITLE
Run git as user, not root

### DIFF
--- a/vagrant/configure-leap.sh
+++ b/vagrant/configure-leap.sh
@@ -10,6 +10,7 @@ NODE='node1'
 SUDO="sudo -u ${USER}"
 PROVIDERDIR="/home/${USER}/leap/configuration"
 LEAP="$SUDO /usr/local/bin/leap"
+GIT="$SUDO git"
 
 echo '==============================================='
 echo 'configuring leap'
@@ -43,9 +44,9 @@ echo '{ "webapp": { "admins": ["testadmin"] } }' > services/webapp.json
 
 $LEAP $OPTS compile
 
-git init
-git add .
-git commit -m'configured provider'
+$GIT init
+$GIT add .
+$GIT commit -m'configured provider'
 
 $LEAP $OPTS node init $NODE
 if [ $? -eq 1 ]; then
@@ -61,8 +62,8 @@ gem install rake
 $LEAP $OPTS -v 2 deploy
 
 set +e
-git add .
-git commit -m'initialized and deployed provider'
+$GIT add .
+$GIT commit -m'initialized and deployed provider'
 set -e
 
 # Vagrant: leap_mx fails to start on jessie


### PR DESCRIPTION
The .git repo had been owned by root, not by the vagrant user. This makes it impossible to change and commit the configuration, e.g. to add puppet-pixelated. This change runs git with a 'sudo -u vagrant'  prefix.