### PR TITLE
leap redirects port 80 to an invalid url

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,6 @@ Vagrant.configure("2") do |box|
     config.ssh.username = "vagrant"
 
     # forward leap_web ports
-    config.vm.network "forwarded_port", guest: 80,  host:8080
     config.vm.network "forwarded_port", guest: 443, host:4443
   end
 
@@ -57,7 +56,6 @@ Vagrant.configure("2") do |box|
     config.ssh.username = "vagrant"
 
     # forward leap_web ports
-    config.vm.network "forwarded_port", guest: 80,  host:8080
     config.vm.network "forwarded_port", guest: 443, host:4443
   end
 end


### PR DESCRIPTION
on vagrant, we use example.org as domain and all
requests to http are redirected to https://example.org
thats why this does not work on vagrant. we connect to
localhost:8080 and get redirected to https://example.org
thats why we do not need this port forwarded