### PR TITLE
finally fix leap-mx logging, for the last time, hopefully.

### DIFF
--- a/puppet/modules/leap/manifests/logfile.pp
+++ b/puppet/modules/leap/manifests/logfile.pp
@@ -1,9 +1,18 @@
 #
 # make syslog log to a particular file for a particular process.
 #
-
-define leap::logfile($process=$name) {
-  $logfile = "/var/log/leap/${name}.log"
+# arguments:
+#
+#   * name: what config files are named as (eg.  /etc/rsyslog.d/50-$name.conf)
+#   * log: the full path of the log file (defaults to /var/log/leap/$name.log
+#   * process: the syslog tag to filter on (defaults to name)
+#
+define leap::logfile($process = $name, $log = undef) {
+  if $log {
+    $logfile = $log
+  } else {
+    $logfile = "/var/log/leap/${name}.log"
+  }
 
   rsyslog::snippet { "50-${name}":
     content => template('leap/rsyslog.erb')

--- a/puppet/modules/leap_mx/manifests/init.pp
+++ b/puppet/modules/leap_mx/manifests/init.pp
@@ -85,7 +85,10 @@ class leap_mx {
     notify  => Service['leap-mx'];
   }
 
-  leap::logfile { 'mx': process => 'leap-mx' }
+  leap::logfile { 'leap-mx':
+    log => '/var/log/leap/mx.log',
+    process => 'leap-mx'
+  }
 
   #
   # LEAP-MX CODE AND DEPENDENCIES

--- a/puppet/modules/site_config/manifests/remove/files.pp
+++ b/puppet/modules/site_config/manifests/remove/files.pp
@@ -15,6 +15,7 @@ class site_config::remove::files {
   tidy {
     '/etc/default/leap_mx':;
     '/etc/logrotate.d/mx':;
+    '/etc/rsyslog.d/50-mx.conf':;
   }
 
   #
@@ -30,11 +31,7 @@ class site_config::remove::files {
     'leap_mx':
       path => '/var/log/',
       recurse => true,
-      matches => 'leap_mx*';
-    'mx':
-      path => '/var/log/leap/',
-      recurse => true,
-      matches => 'mx.log*';
+      matches => ['leap_mx*', 'mx.log.[6-9](.gz)?', 'mx.log.[0-9][0-9](.gz)?'];
     '/srv/leap/webapp/public/provider.json':;
     '/srv/leap/couchdb/designs/tmp_users':
       recurse => true,


### PR DESCRIPTION
the previous commit that was intended to fix the leap mx problems once and for all had a few problems (https://gitlab.com/leap/platform/merge_requests/118/diffs)

* leap-mx was logging to /var/log/leap/mx.log, but also those files were getting purged on every deploy.
* the config files for leap-mx logging for rsyslog and logrotate were called 'mx', which is not as clear as 'leap-mx'.