### PR TITLE
debian packages don't know AllowSupplementaryGroups

### DIFF
--- a/puppet/modules/clamav/templates/clamav-milter.conf.erb
+++ b/puppet/modules/clamav/templates/clamav-milter.conf.erb
@@ -4,7 +4,6 @@ FixStaleSocket true
 User clamav
 MilterSocketGroup clamav
 MilterSocketMode 666
-AllowSupplementaryGroups true
 ReadTimeout 120
 Foreground false
 PidFile /var/run/clamav/clamav-milter.pid


### PR DESCRIPTION
if this is set in the config, the deamons do not
start anymore. From the debian changelog:

  clamav (0.99.2+dfsg-0+deb8u1) stable; urgency=medium
  * Import new Upstream.
  * Drop AllowSupplementaryGroups option which is default now
    (Closes: #822444).